### PR TITLE
chore: Add Scala Steward workflow

### DIFF
--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -1,0 +1,20 @@
+name: Scala Steward
+
+# This workflow will launch at 03:00 every Monday.
+on:
+  schedule:
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+jobs:
+  scala-steward:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    name: Launch Scala Steward
+    steps:
+      - name: Launch Scala Steward
+        uses: scala-steward-org/scala-steward-action@v2
+        with:
+          github-token: ${{ secrets.GATLING_CI_TOKEN }}
+          author-email: ${{ secrets.GATLING_CI_NAME }}
+          author-name: ${{ secrets.GATLING_CI_EMAIL }}


### PR DESCRIPTION
Requires the same secrets as our other Scala Steward workflows: `GATLING_CI_TOKEN`, `GATLING_CI_NAME`, `GATLING_CI_EMAIL`.